### PR TITLE
test was not working correctly without /playlists

### DIFF
--- a/P07-Adding-Tests/content.md
+++ b/P07-Adding-Tests/content.md
@@ -84,7 +84,7 @@ class PlaylistsTests(TestCase):
     ...
     def test_index(self):
         """Test the playlists homepage."""
-        result = self.client.get('/')
+        result = self.client.get('/playlists')
         self.assertEqual(result.status, '200 OK')
 
         page_content = result.get_data(as_text=True)


### PR DESCRIPTION
This was the error without adding the /playlists

Traceback (most recent call last):
  File "/Users/xxxxxxx/code/playlister/tests.py", line 19, in test_index
    self.assertEqual(result.status, '200 OK')
AssertionError: '302 FOUND' != '200 OK'
- 302 FOUND
+ 200 OK